### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ This is a modified version of the original mcp-server-fetch that removes all rob
 > [!CAUTION]
 > This server can access local/internal IP addresses and may represent a security risk. Exercise caution when using this MCP server to ensure this does not expose any sensitive data. Additionally, this version ignores robots.txt restrictions which may violate some websites' access policies.
 
+<a href="https://glama.ai/mcp/servers/@LangGPT/mcp-fetch">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@LangGPT/mcp-fetch/badge" alt="Fetch MCP server" />
+</a>
+
 The fetch tool will truncate the response, but by using the `start_index` argument, you can specify where to start the content extraction. This lets models read a webpage in chunks, until they find the information they need.
 
 ## Available Tools


### PR DESCRIPTION
This PR adds a badge for the [MCP Fetch](https://glama.ai/mcp/servers/@LangGPT/mcp-fetch) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@LangGPT/mcp-fetch">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@LangGPT/mcp-fetch/badge" alt="Fetch MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.